### PR TITLE
Change shebang to #!/usr/bin/env python3

### DIFF
--- a/check_spectrum_scale.py
+++ b/check_spectrum_scale.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 ################################################################################
 #  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
Simple change to use `#!/usr/bin/env python3` for the shebang in order to run using any python3 found in `$PATH`.